### PR TITLE
Add LocoParser tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/LocoParser/.vs
+/LocoParser/x64
+/LocoParser/LocoParser/x64
+/LocoParser/LocoParser/*.user
+/LocoParser/build

--- a/LocoParser/.clang-format
+++ b/LocoParser/.clang-format
@@ -1,0 +1,93 @@
+---
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: true
+ColumnLimit:     128
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: 'Regroup'
+IncludeCategories:
+  - Regex:           '^"'
+    Priority:        1
+  - Regex:           '^<'
+    Priority:        2
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+PenaltyBreakAssignment: 1000
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+UseTab:          Never
+...

--- a/LocoParser/CMakeLists.txt
+++ b/LocoParser/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required (VERSION 3.15)
+project (LocoParser)
+
+add_subdirectory (LocoParser)

--- a/LocoParser/LocoParser.sln
+++ b/LocoParser/LocoParser.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31727.386
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LocoParser", "LocoParser\LocoParser.vcxproj", "{D8E06E86-E75E-4609-9A54-DB23F24EDC17}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D8E06E86-E75E-4609-9A54-DB23F24EDC17}.Debug|x64.ActiveCfg = Debug|x64
+		{D8E06E86-E75E-4609-9A54-DB23F24EDC17}.Debug|x64.Build.0 = Debug|x64
+		{D8E06E86-E75E-4609-9A54-DB23F24EDC17}.Release|x64.ActiveCfg = Release|x64
+		{D8E06E86-E75E-4609-9A54-DB23F24EDC17}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1F4CE44F-F1F3-4909-9760-CD5E5972AF2F}
+	EndGlobalSection
+EndGlobal

--- a/LocoParser/LocoParser/CMakeLists.txt
+++ b/LocoParser/LocoParser/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(LocoParser)
+
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+
+find_package(Filesystem REQUIRED)
+
+find_package(Clang REQUIRED)
+add_library(Clang INTERFACE)
+target_link_libraries(Clang INTERFACE libclang)
+target_include_directories(Clang INTERFACE "${CLANG_INCLUDE_DIRS}")
+target_compile_definitions(Clang INTERFACE ${LLVM_DEFINITIONS})
+
+add_executable(locoparser main.cpp)
+target_compile_features(locoparser PRIVATE cxx_std_20)
+target_link_libraries(locoparser PRIVATE Clang)
+target_link_libraries(locoparser PRIVATE std::filesystem)

--- a/LocoParser/LocoParser/LocoParser.vcxproj
+++ b/LocoParser/LocoParser/LocoParser.vcxproj
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{d8e06e86-e75e-4609-9a54-db23f24edc17}</ProjectGuid>
+    <RootNamespace>LocoParser</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)build\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)build\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>C:\Program Files\LLVM\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>C:\Program Files\LLVM\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libclang.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>C:\Program Files\LLVM\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>C:\Program Files\LLVM\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libclang.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/LocoParser/LocoParser/LocoParser.vcxproj.filters
+++ b/LocoParser/LocoParser/LocoParser.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+</Project>

--- a/LocoParser/LocoParser/cmake/modules/FindFilesystem.cmake
+++ b/LocoParser/LocoParser/cmake/modules/FindFilesystem.cmake
@@ -1,0 +1,244 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+# This is copied from:
+#   https://github.com/vector-of-bool/CMakeCM/blob/master/modules/FindFilesystem.cmake
+
+#[=======================================================================[.rst:
+
+FindFilesystem
+##############
+
+This module supports the C++17 standard library's filesystem utilities. Use the
+:imp-target:`std::filesystem` imported target to
+
+Options
+*******
+
+The ``COMPONENTS`` argument to this module supports the following values:
+
+.. find-component:: Experimental
+    :name: fs.Experimental
+
+    Allows the module to find the "experimental" Filesystem TS version of the
+    Filesystem library. This is the library that should be used with the
+    ``std::experimental::filesystem`` namespace.
+
+.. find-component:: Final
+    :name: fs.Final
+
+    Finds the final C++17 standard version of the filesystem library.
+
+If no components are provided, behaves as if the
+:find-component:`fs.Final` component was specified.
+
+If both :find-component:`fs.Experimental` and :find-component:`fs.Final` are
+provided, first looks for ``Final``, and falls back to ``Experimental`` in case
+of failure. If ``Final`` is found, :imp-target:`std::filesystem` and all
+:ref:`variables <fs.variables>` will refer to the ``Final`` version.
+
+
+Imported Targets
+****************
+
+.. imp-target:: std::filesystem
+
+    The ``std::filesystem`` imported target is defined when any requested
+    version of the C++ filesystem library has been found, whether it is
+    *Experimental* or *Final*.
+
+    If no version of the filesystem library is available, this target will not
+    be defined.
+
+    .. note::
+        This target has ``cxx_std_17`` as an ``INTERFACE``
+        :ref:`compile language standard feature <req-lang-standards>`. Linking
+        to this target will automatically enable C++17 if no later standard
+        version is already required on the linking target.
+
+
+.. _fs.variables:
+
+Variables
+*********
+
+.. variable:: CXX_FILESYSTEM_IS_EXPERIMENTAL
+
+    Set to ``TRUE`` when the :find-component:`fs.Experimental` version of C++
+    filesystem library was found, otherwise ``FALSE``.
+
+.. variable:: CXX_FILESYSTEM_HAVE_FS
+
+    Set to ``TRUE`` when a filesystem header was found.
+
+.. variable:: CXX_FILESYSTEM_HEADER
+
+    Set to either ``filesystem`` or ``experimental/filesystem`` depending on
+    whether :find-component:`fs.Final` or :find-component:`fs.Experimental` was
+    found.
+
+.. variable:: CXX_FILESYSTEM_NAMESPACE
+
+    Set to either ``std::filesystem`` or ``std::experimental::filesystem``
+    depending on whether :find-component:`fs.Final` or
+    :find-component:`fs.Experimental` was found.
+
+
+Examples
+********
+
+Using `find_package(Filesystem)` with no component arguments:
+
+.. code-block:: cmake
+
+    find_package(Filesystem REQUIRED)
+
+    add_executable(my-program main.cpp)
+    target_link_libraries(my-program PRIVATE std::filesystem)
+
+
+#]=======================================================================]
+
+
+if(TARGET std::filesystem)
+    # This module has already been processed. Don't do it again.
+    return()
+endif()
+
+cmake_policy(PUSH)
+if(POLICY CMP0067)
+    # pass CMAKE_CXX_STANDARD to check_cxx_source_compiles()
+    # has to appear before including CheckCXXSourceCompiles module
+    cmake_policy(SET CMP0067 NEW)
+endif()
+
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
+include(CheckCXXSourceCompiles)
+
+cmake_push_check_state()
+
+set(CMAKE_REQUIRED_QUIET ${Filesystem_FIND_QUIETLY})
+
+# All of our tests required C++17 or later
+set(CMAKE_CXX_STANDARD 17)
+
+# Normalize and check the component list we were given
+set(want_components ${Filesystem_FIND_COMPONENTS})
+if(Filesystem_FIND_COMPONENTS STREQUAL "")
+    set(want_components Final)
+endif()
+
+# Warn on any unrecognized components
+set(extra_components ${want_components})
+list(REMOVE_ITEM extra_components Final Experimental)
+foreach(component IN LISTS extra_components)
+    message(WARNING "Extraneous find_package component for Filesystem: ${component}")
+endforeach()
+
+# Detect which of Experimental and Final we should look for
+set(find_experimental TRUE)
+set(find_final TRUE)
+if(NOT "Final" IN_LIST want_components)
+    set(find_final FALSE)
+endif()
+if(NOT "Experimental" IN_LIST want_components)
+    set(find_experimental FALSE)
+endif()
+
+if(find_final)
+    check_include_file_cxx("filesystem" _CXX_FILESYSTEM_HAVE_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_HEADER)
+    if(_CXX_FILESYSTEM_HAVE_HEADER)
+        # We found the non-experimental header. Don't bother looking for the
+        # experimental one.
+        set(find_experimental FALSE)
+    endif()
+else()
+    set(_CXX_FILESYSTEM_HAVE_HEADER FALSE)
+endif()
+
+if(find_experimental)
+    check_include_file_cxx("experimental/filesystem" _CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+else()
+    set(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER FALSE)
+endif()
+
+if(_CXX_FILESYSTEM_HAVE_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header filesystem)
+    set(_fs_namespace std::filesystem)
+elseif(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header experimental/filesystem)
+    set(_fs_namespace std::experimental::filesystem)
+else()
+    set(_have_fs FALSE)
+endif()
+
+set(CXX_FILESYSTEM_HAVE_FS ${_have_fs} CACHE BOOL "TRUE if we have the C++ filesystem headers")
+set(CXX_FILESYSTEM_HEADER ${_fs_header} CACHE STRING "The header that should be included to obtain the filesystem APIs")
+set(CXX_FILESYSTEM_NAMESPACE ${_fs_namespace} CACHE STRING "The C++ namespace that contains the filesystem APIs")
+
+set(_found FALSE)
+
+if(CXX_FILESYSTEM_HAVE_FS)
+    # We have some filesystem library available. Do link checks
+    string(CONFIGURE [[
+        #include <@CXX_FILESYSTEM_HEADER@>
+
+        int main() {
+            auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
+            return static_cast<int>(cwd.string().size());
+        }
+    ]] code @ONLY)
+
+    # Try to compile a simple filesystem program without any linker flags
+    check_cxx_source_compiles("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+
+    set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
+
+    if(NOT CXX_FILESYSTEM_NO_LINK_NEEDED)
+        set(prev_libraries ${CMAKE_REQUIRED_LIBRARIES})
+        # Add the libstdc++ flag
+        set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lstdc++fs)
+        check_cxx_source_compiles("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
+        set(can_link ${CXX_FILESYSTEM_STDCPPFS_NEEDED})
+        if(NOT CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            # Try the libc++ flag
+            set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lc++fs)
+            check_cxx_source_compiles("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
+            set(can_link ${CXX_FILESYSTEM_CPPFS_NEEDED})
+        endif()
+    endif()
+
+    if(can_link)
+        add_library(std::filesystem INTERFACE IMPORTED)
+        target_compile_features(std::filesystem INTERFACE cxx_std_17)
+        set(_found TRUE)
+        if(CXX_FILESYSTEM_NO_LINK_NEEDED)
+            # on certain linux distros we have a version of libstdc++ which has the final code for c++17 fs in the
+            # libstdc++.so.*. BUT when compiling with g++ < 9, we MUST still link with libstdc++fs.a 
+            # libc++ should not suffer from this issue, so, in theory we should be fine with only checking for
+            # GCC's libstdc++ 
+            if((CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0.0"))
+                target_link_libraries(std::filesystem INTERFACE -lstdc++fs)
+            endif()
+        elseif(CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            target_link_libraries(std::filesystem INTERFACE -lstdc++fs)
+        elseif(CXX_FILESYSTEM_CPPFS_NEEDED)
+            target_link_libraries(std::filesystem INTERFACE -lc++fs)
+        endif()
+    endif()
+endif()
+
+cmake_pop_check_state()
+
+set(Filesystem_FOUND ${_found} CACHE BOOL "TRUE if we can compile and link a program using std::filesystem" FORCE)
+
+if(Filesystem_FIND_REQUIRED AND NOT Filesystem_FOUND)
+    message(FATAL_ERROR "Cannot Compile simple program using std::filesystem")
+endif()
+
+cmake_policy(POP)

--- a/LocoParser/LocoParser/main.cpp
+++ b/LocoParser/LocoParser/main.cpp
@@ -1,0 +1,433 @@
+#include <algorithm>
+#include <clang-c/Index.h>
+#include <codecvt>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <numeric>
+#include <vector>
+
+#ifdef _MSC_VER
+#    include <execution>
+#endif
+
+#include <filesystem>
+namespace stdfs = std::filesystem;
+
+static std::mutex sMtx;
+
+static std::string getString(CXString s)
+{
+    const auto* cstr = clang_getCString(s);
+    if (cstr == nullptr)
+        return {};
+
+    std::string res(cstr);
+    clang_disposeString(s);
+    return res;
+}
+
+static std::vector<std::string> split(const std::string& s, const std::string& delim)
+{
+    const size_t searchLen = delim.length();
+
+    size_t startIdx = 0;
+    size_t endIdx = 0;
+    std::string token;
+    std::vector<std::string> res;
+    while ((endIdx = s.find(delim, startIdx)) != std::string::npos)
+    {
+        token = s.substr(startIdx, endIdx - startIdx);
+        startIdx = endIdx + searchLen;
+        res.push_back(token);
+    }
+    res.push_back(s.substr(startIdx));
+    return res;
+}
+
+static std::vector<std::string> tokenize(const std::string& s)
+{
+    std::vector<std::string> res;
+    std::string cur;
+    for (size_t i = 0; i < s.size(); i++)
+    {
+        auto chr = s[i];
+        if (isalnum(chr))
+        {
+            cur += chr;
+        }
+        else
+        {
+            if (!cur.empty())
+            {
+                res.push_back(cur);
+                cur.clear();
+            }
+
+            cur += chr;
+            res.push_back(cur);
+            cur.clear();
+        }
+    }
+    if (!cur.empty())
+    {
+        res.push_back(cur);
+    }
+    return res;
+}
+
+static std::vector<std::string> extractAddresses(const std::string& txt)
+{
+    auto lines = split(txt, "\n");
+    if (lines.empty())
+        return {};
+
+    auto line = lines[0];
+    while (!line.empty() && (line.front() == '/' || line.front() == ' '))
+    {
+        line = line.substr(1);
+    }
+    if (line.empty())
+        return {};
+
+    std::vector<std::string> res;
+    auto tokens = tokenize(line);
+    for (auto& token : tokens)
+    {
+        if (token.starts_with("0x") || token.starts_with("0X"))
+        {
+            res.push_back(token);
+        }
+    }
+
+    return res;
+}
+
+static std::vector<stdfs::path> findFiles(const std::string_view path)
+{
+    std::vector<stdfs::path> res;
+
+    using iter = stdfs::recursive_directory_iterator;
+    for (auto& entry : iter(stdfs::path(path)))
+    {
+        if (!entry.is_regular_file() || entry.is_symlink())
+            continue;
+
+        stdfs::path filePath = entry;
+        auto ext = filePath.extension();
+        if (ext != ".cpp")
+            continue;
+
+        res.push_back(filePath);
+    }
+
+    return res;
+}
+
+struct FunctionDef
+{
+    std::string address;
+    std::string name;
+};
+
+struct VarDef
+{
+    std::string address;
+    std::string name;
+};
+
+struct ParserContext
+{
+    std::vector<FunctionDef> funcs;
+    std::vector<VarDef> vars;
+};
+
+static void checkFuncDecl(ParserContext& ctx, CXCursor c)
+{
+    auto strMangled = getString(clang_Cursor_getMangling(c));
+    auto strComment = getString(clang_Cursor_getRawCommentText(c));
+    if (strComment.empty())
+        return;
+
+    auto addrs = extractAddresses(strComment);
+    if (addrs.empty())
+        return;
+
+    for (size_t i = 0; i < addrs.size(); i++)
+    {
+        auto name = strMangled;
+        if (i > 0)
+            name += "_" + std::to_string(i);
+
+        {
+            std::lock_guard lock(sMtx);
+            ctx.funcs.push_back(FunctionDef{ addrs[i], name });
+        }
+    }
+}
+
+static void checkVarDecl(ParserContext& ctx, CXCursor c, CXCursor parent)
+{
+    auto spelling = getString(clang_getCursorSpelling(c));
+    if (spelling != "loco_global")
+        return;
+
+    auto varName = getString(clang_getCursorSpelling(parent));
+
+    auto cursorType = clang_getCursorType(parent);
+    auto canonicalType = clang_getCanonicalType(cursorType);
+    auto typeStr = getString(clang_getTypeSpelling(canonicalType));
+
+    auto n1 = typeStr.find_first_of(',') + 1;
+    while (typeStr[n1] == ' ')
+        n1++;
+    auto n2 = typeStr.find_first_of('>', n1);
+    auto addrVal = typeStr.substr(n1, (n2 - n1));
+    auto addr = atol(addrVal.c_str());
+
+    {
+        char addrString[64]{};
+        sprintf(addrString, "0x%08X", static_cast<uint32_t>(addr));
+
+        std::lock_guard lock(sMtx);
+        ctx.vars.push_back({ addrString, varName });
+    }
+}
+
+// 100% horrible.
+static std::string toMb(const auto* str)
+{
+    std::string res;
+    while (*str != 0)
+    {
+        res += static_cast<char>(*str);
+        str++;
+    }
+    return res;
+}
+
+static bool parseFiles(ParserContext& ctx, const std::vector<stdfs::path>& files)
+{
+    const char* cmdLineArgs[] = {
+        "-fparse-all-comments",
+    };
+
+    CXIndex index = clang_createIndex(0, 0);
+
+    std::vector<size_t> indices(files.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+#ifdef _MSC_VER
+    std::for_each(std::execution::par, indices.begin(), indices.end(), [&](auto i) {
+#else
+    std::for_each(indices.begin(), indices.end(), [&](auto i) {
+#endif
+        const auto& path = files[i];
+
+        std::string filePath = toMb(path.c_str());
+
+        {
+            std::lock_guard lock(sMtx);
+            std::cout << "[" << (i + 1) << "/" << files.size() << "] Parsing '" << filePath << "'... \n";
+        }
+
+        CXTranslationUnit unit = clang_parseTranslationUnit(
+            index, filePath.c_str(), cmdLineArgs, (int)std::size(cmdLineArgs), nullptr, 0,
+            CXTranslationUnit_DetailedPreprocessingRecord | CXTranslationUnit_IncludeBriefCommentsInCodeCompletion);
+
+        if (unit == nullptr)
+        {
+            std::cerr << "Unable to parse translation unit. Quitting." << std::endl;
+            return;
+        }
+
+        CXCursor cursor = clang_getTranslationUnitCursor(unit);
+        clang_visitChildren(
+            cursor,
+            [](CXCursor c, CXCursor parent, CXClientData client_data) {
+                auto& ctx = *reinterpret_cast<ParserContext*>(client_data);
+                auto kind = clang_getCursorKind(c);
+                if (kind == CXCursor_FunctionDecl || kind == CXCursor_CXXMethod)
+                {
+                    checkFuncDecl(ctx, c);
+                }
+                else if (kind == CXCursor_TemplateRef && clang_getCursorKind(parent) == CXCursor_VarDecl)
+                {
+                    checkVarDecl(ctx, c, parent);
+                }
+                return CXChildVisit_Recurse;
+            },
+            &ctx);
+
+        clang_disposeTranslationUnit(unit);
+    });
+
+    std::sort(ctx.funcs.begin(), ctx.funcs.end(), [](auto& a, auto& b) { return a.address < b.address; });
+    ctx.funcs.erase(
+        std::unique(ctx.funcs.begin(), ctx.funcs.end(), [](auto& a, auto& b) { return a.address == b.address; }),
+        ctx.funcs.end());
+
+    std::sort(ctx.vars.begin(), ctx.vars.end(), [](auto& a, auto& b) { return a.address < b.address; });
+    ctx.vars.erase(
+        std::unique(ctx.vars.begin(), ctx.vars.end(), [](auto& a, auto& b) { return a.address == b.address; }), ctx.vars.end());
+
+    clang_disposeIndex(index);
+
+    return true;
+}
+
+static void dumpCursor(CXCursor c, CXCursor parent)
+{
+    auto parentSpelling = getString(clang_getCursorSpelling(parent));
+
+    auto spelling = getString(clang_getCursorSpelling(c));
+    auto cursorKind = clang_getCursorKind(c);
+    auto kindSpelling = getString(clang_getCursorKindSpelling(cursorKind));
+
+    auto cursorType = clang_getCursorType(parent);
+    auto canonicalType = clang_getCanonicalType(cursorType);
+    auto typeStr = getString(clang_getTypeSpelling(canonicalType));
+    auto strComment = getString(clang_Cursor_getRawCommentText(c));
+
+    std::cout << "NODE: " << spelling << "\n";
+    std::cout << "-> Parent: " << parentSpelling << "\n";
+    std::cout << "-> Kind: " << kindSpelling << "\n";
+    std::cout << "-> Comment: " << strComment << "\n";
+}
+
+static bool dumpAST(const std::string& filePath)
+{
+    const char* cmdLineArgs[] = {
+        "-fparse-all-comments",
+    };
+
+    CXIndex index = clang_createIndex(0, 0);
+
+    CXTranslationUnit unit = clang_parseTranslationUnit(
+        index, filePath.c_str(), cmdLineArgs, (int)std::size(cmdLineArgs), nullptr, 0,
+        CXTranslationUnit_DetailedPreprocessingRecord | CXTranslationUnit_IncludeBriefCommentsInCodeCompletion);
+
+    if (unit == nullptr)
+    {
+        std::cerr << "Unable to parse translation unit. Quitting." << std::endl;
+        return false;
+    }
+
+    CXCursor cursor = clang_getTranslationUnitCursor(unit);
+    clang_visitChildren(
+        cursor,
+        [](CXCursor c, CXCursor parent, CXClientData client_data) {
+            dumpCursor(c, parent);
+            return CXChildVisit_Recurse;
+        },
+        nullptr);
+
+    clang_disposeTranslationUnit(unit);
+    clang_disposeIndex(index);
+
+    return true;
+}
+
+static bool dumpIdc(ParserContext& ctx)
+{
+    std::cout << "Dumping name.idc... ";
+
+    std::ofstream nameFile("names.idc");
+    if (!nameFile.is_open())
+    {
+        std::cerr << "Unable to open names.idc\n";
+        return false;
+    }
+
+    nameFile << "#include <idc.idc>\n";
+    nameFile << "\n";
+    nameFile << "static main(void)\n";
+    nameFile << "{\n";
+    nameFile << "    // Functions\n";
+    for (auto& entry : ctx.funcs)
+    {
+        nameFile << "    set_name(" << entry.address << ", \"" << entry.name << "\", SN_FORCE);\n";
+    }
+
+    nameFile << "    // Globals\n";
+    for (auto& entry : ctx.vars)
+    {
+        nameFile << "    set_name(" << entry.address << ", \"" << entry.name << "\", SN_FORCE);\n";
+    }
+    nameFile << "}\n";
+
+    std::cout << "OK\n";
+    return true;
+}
+
+int main(int argc, const char* argv[])
+{
+    enum class Action
+    {
+        Invalid = 0,
+        MakeIDC,
+        DumpAST,
+    } action{};
+
+    std::string inputFileOrFolder;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-d") == 0)
+            action = Action::DumpAST;
+        else if (strcmp(argv[i], "-p") == 0)
+            action = Action::MakeIDC;
+        else if (strcmp(argv[i], "-f") == 0)
+        {
+            if (i + 1 >= argc)
+            {
+                std::cerr << "Missing argument for -f\n";
+                return EXIT_FAILURE;
+            }
+            inputFileOrFolder = argv[++i];
+        }
+    }
+
+    if (action == Action::Invalid)
+    {
+        std::cerr << "No action specified (-d, -p)\n";
+        return EXIT_FAILURE;
+    }
+
+    if (inputFileOrFolder.empty())
+    {
+        std::cerr << "Missing argument for -f\n";
+        return EXIT_FAILURE;
+    }
+
+    if (action == Action::MakeIDC)
+    {
+        auto files = findFiles(inputFileOrFolder);
+        if (files.empty())
+        {
+            std::cerr << "No files found to process\n";
+            return EXIT_FAILURE;
+        }
+
+        ParserContext ctx;
+        if (!parseFiles(ctx, files))
+        {
+            return EXIT_FAILURE;
+        }
+
+        if (!dumpIdc(ctx))
+        {
+            return EXIT_FAILURE;
+        }
+    }
+    else if (action == Action::DumpAST)
+    {
+        if (!dumpAST(inputFileOrFolder))
+        {
+            return EXIT_FAILURE;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/LocoParser/build.sh
+++ b/LocoParser/build.sh
@@ -1,0 +1,2 @@
+cmake -B build -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+cmake --build build


### PR DESCRIPTION
This tool uses libclang to parse all source code and extracts functions with an address comment such as ```// 0x000000``` and parses all ```loco_global``` and generates a names.idc.

Note: The current names.idc should not be replaced with the generated one, it has its own entry point in the script.
Note 2: The current path for libclang is currently hardwired to Program Files installation path.